### PR TITLE
 feat(api): add endpoint with complexe custom type

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/Resources/CustomerGroup.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/CustomerGroup.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\Resources;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\AddCustomerGroupCommand;
+use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
+
+#[ApiResource(
+    operations: [
+        new Post(
+            uriTemplate: '/customers/group',
+            provider: CommandProcessor::class,
+            extraProperties: [
+                'command' => AddCustomerGroupCommand::class,
+            ],
+        ),
+    ]
+)]
+class CustomerGroup
+{
+    /**
+     * @param string[] $localizedNames
+     * @param int[] $shopIds
+     */
+    public function __construct(
+        #[ApiProperty(
+            example: 'array<string>',
+        )]
+        public array $localizedNames,
+        #[ApiProperty(
+            openapiContext: [
+                'example' => [
+                    'exponent' => 'int',
+                    'number' => 'string',
+                ],
+            ],
+        )]
+        public DecimalNumber $reductionPercent,
+        public bool $displayPriceTaxExcluded,
+        public bool $showPrice,
+        #[ApiProperty(
+            example: 'array<int>',
+        )]
+        public array $shopIds
+    ) {
+    }
+}

--- a/tests/Integration/ApiPlatform/PostCustomerTest.php
+++ b/tests/Integration/ApiPlatform/PostCustomerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ApiPlatform;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use Tests\Resources\DatabaseDump;
+
+class PostCustomerTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['group']);
+    }
+
+    public function testAddCustomerGroup(): void
+    {
+        $bearerToken = $this->getBearerToken();
+        static::createClient()->request('POST', '/new-api/customers/group', [
+            'auth_bearer' => $bearerToken,
+            'json' => [
+                'localizedNames' => [
+                    'test1',
+                    'test2',
+                ],
+                'reductionPercent' => [
+                    'number' => '10',
+                    'exponent' => 1,
+                ],
+                'displayPriceTaxExcluded' => true,
+                'showPrice' => true,
+                'shopIds' => [1],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+    }
+
+    private function getBearerToken(): string
+    {
+        $parameters = ['parameters' => [
+            'client_id' => 'my_client_id',
+            'client_secret' => 'prestashop',
+            'grant_type' => 'client_credentials',
+        ]];
+        $options = ['extra' => $parameters];
+        $response = static::createClient()->request('POST', '/api/oauth2/token', $options);
+
+        return json_decode($response->getContent())->access_token;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add a new query that demonstrate how to handle custom objects as a parameter in api platform
| Type?             |  new feature 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | <ul><li>Get an bearer token by requesting the /api/oauth2/token endpoint</li><li> Create a new customer group by requesting this endpoint `/customers/group` </li></ul>
| Fixed ticket?     | Fixes #32804
| Related PRs       | N/A
| Sponsor company   | Prestashop 

More informations on how to get your bearer token :

You need to add a return statement at the start of the onKernelRequest method of the SslMiddleware.php file. If you don't do this postman won't be able to handle the current ssl protocol.
You need to modify the security_dev.yml and copy the user key of the oauth2 node from the security_test.yml

More informations about the post : 
* You need to request the endpoint with a payload looking like the following : 
```
{
  "localizedNames": [
      "toto",
      "tata"
  ],
  "reductionPercent": {
    "number": "10",
    "exponent": 1
  },
  "displayPriceTaxExcluded": true,
  "showPrice": true,
  "shopIds": [1]
}
```